### PR TITLE
Avoid deprecated spotless configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ spotless {
     format 'misc', {
         target '*.gradle', '.gitattributes', '.gitignore'
         trimTrailingWhitespace()
-        indentWithSpaces()
+        leadingTabsToSpaces()
         endWithNewline()
     }
     java {


### PR DESCRIPTION
`indentWithSpaces` is deprecated and replaced by `leadingTabsToSpaces`.